### PR TITLE
Overflow auto on expand and set text

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,11 @@ ExpandToggle.prototype.init = function() {
 
   this.maxHeight = this.options.maxHeight || this.container.outerHeight();
 
+  if (this.options.expandedText) {
+    this.collapsedText = this.el.text();
+    this.expandedText = this.options.expandedText || this.collapsedText;
+  }
+
   if (this.options.expanded) {
     this.expand();
   } else {
@@ -62,6 +67,9 @@ ExpandToggle.prototype.collapse = function() {
   this.parent.removeClass(this.options.expandedClass);
   this.container.height(this.options.height);
   this.isExpanded = false;
+  if (this.collapsedText) {
+    this.el.html(this.collapsedText);
+  }
 };
 
 /**
@@ -71,6 +79,9 @@ ExpandToggle.prototype.expand = function() {
   this.parent.addClass(this.options.expandedClass);
   this.container.height(this.maxHeight);
   this.isExpanded = true;
+  if (this.options.expandedText) {
+    this.el.html(this.expandedText);
+  }
 };
 
 /**


### PR DESCRIPTION
Okkkk so this is something that I needed in my project but I haven't still convinced myself it should live in this component.

This patch does two things:
1. It will set the `overflow` of the container to `auto` when it is expanded to make sure that you can scroll within the container when expanded beyond `maxHeight`. If you don't have `maxHeight` set this will have no effect.
2. It enables you to set `data-expanded-text` to a string that will replace the text in the `el` element when expanded and then replace _that_ text with the original when collapsing.

I feel like 1. is probably cool but 2. feel a bit hackish to me so I figure I'd open up a PR and see what you think! :)
